### PR TITLE
refactoring spinners and query asynchrony

### DIFF
--- a/src/main/webapp/common/spinner.hbs
+++ b/src/main/webapp/common/spinner.hbs
@@ -1,0 +1,2 @@
+<div class="spinner {{this}}" style="position: relative;"></div>
+	

--- a/src/main/webapp/common/spinner.js
+++ b/src/main/webapp/common/spinner.js
@@ -1,0 +1,32 @@
+define(["text!common/spinner.hbs", "handlebars"], function(template, HBS){
+	var template = HBS.compile(template);
+	
+	var createSpinner = function(deferredAction, targetDivSelector, classes){
+		$.when(deferredAction).then(function(){
+			if(typeof targetDivSelector === "function"){
+				targetDivSelector.html("");
+			}else{
+				$(targetDivSelector).html("");				
+			}
+		});
+		$(targetDivSelector).html(template(classes))
+	};
+	
+	var createSmallSpinner = function(deferredAction, targetDivSelector, classes){
+		createSpinner(deferredAction, targetDivSelector, "spinner-center " + classes);
+	};
+	
+	var createMediumSpinner = function(deferredAction, targetDivSelector, classes){
+		createSpinner(deferredAction, targetDivSelector, "spinner-medium spinner-medium-center " + classes);
+	};
+	
+	var createLargeSpinner = function(deferredAction, targetDivSelector, classes){
+		createSpinner(deferredAction, targetDivSelector, "spinner-large spinner-large-center " + classes);
+	};
+	
+	return {
+		small : createSmallSpinner,
+		medium : createMediumSpinner,
+		large : createLargeSpinner
+	};
+});

--- a/src/main/webapp/filter/filter.hbs
+++ b/src/main/webapp/filter/filter.hbs
@@ -12,8 +12,8 @@
 			    </ul>
 			</div>
 		</div>
-		<div class="filter-search-box col-md-3">
-		    <div class="spinner" style="display: none; position: absolute; right: 10%;"></div>
+		<div class="filter-search-box col-md-6">
+		    <div class="spinner-div"></div>
 		    <input class="search-box form-control" placeholder="Search..." value="{{searchTerm}}">
 		</div>
 		<div class="search-button col-md-1">

--- a/src/main/webapp/filter/filter.js
+++ b/src/main/webapp/filter/filter.js
@@ -1,5 +1,5 @@
-define(["backbone", "handlebars", "text!filter/filter.hbs", "text!filter/suggestion.hbs", "autocomplete"], 
-		function(BB, HBS, filterTemplate, suggestionTemplate){
+define(["common/spinner", "backbone", "handlebars", "text!filter/filter.hbs", "text!filter/suggestion.hbs", "autocomplete"], 
+		function(spinner, BB, HBS, filterTemplate, suggestionTemplate){
 	var filterModel = BB.Model.extend({
 		defaults:{
 			inclusive: true,
@@ -36,11 +36,12 @@ define(["backbone", "handlebars", "text!filter/filter.hbs", "text!filter/suggest
 				return;
 			}
 			this.$el.html(this.template(this.model));
-            var spinner = this.$el.find(".spinner");
+			var spinnerSelector = this.$el.find(".spinner-div");
 			$('.search-box', this.$el).autocomplete({
-                deferRequestBy: 300,
+				deferRequestBy: 300,
 				lookup: function (query, done) {
 					var result = {};
+					var lookupDeferred = $.Deferred();
 					$.ajax({
 						url: "/" + sessionStorage.environment + "/resourceService/find?term=%25"+query+"%25",
 						success: function(response){
@@ -81,12 +82,12 @@ define(["backbone", "handlebars", "text!filter/filter.hbs", "text!filter/suggest
 							}
 							done(result);
 						},
-                        beforeSend: function(){
-                            spinner.show();
+						beforeSend: function(){
+							spinner.small(lookupDeferred, spinnerSelector, "search-box-spinner");
 						},
-                        complete: function(){
-                            spinner.hide();
-                        },
+						complete: function(){
+							lookupDeferred.resolve();
+						},
 						headers: {
 							"Authorization": "Bearer " + sessionStorage.token
 						},
@@ -101,7 +102,7 @@ define(["backbone", "handlebars", "text!filter/filter.hbs", "text!filter/suggest
 				}.bind(this),
 				triggerSelectOnValidInput: false,
 				minChars: 2,
-                showNoSuggestionNotice: true,
+				showNoSuggestionNotice: true,
 				noSuggestionNotice: "Sorry, no results found. Please try synonyms or more general terms for your query."
 			});
 			$('.dropdown-toggle', this.$el).dropdown();

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -53,6 +53,6 @@
 		</div>
 		<div id="query-results" class="col-md-4"></div>
 	</div>
-
+	
 </body>
 </html>

--- a/src/main/webapp/output/outputPanel.hbs
+++ b/src/main/webapp/output/outputPanel.hbs
@@ -1,6 +1,6 @@
 <div id="patient-count-box">
-	<div id="patient-spinner" class="spinner spinner-large spinner-large-center" style="position: relative; display: none;"></div>
-	<span id="patient-count" class="blue center large">0</span><br>
+	<span class="center large" id="spinner-total"></span>
+	<span id="patient-count" class="blue center large"></span><br>
 	<span class="center medium">Total Patients</span><br>
 	<div class="container" id="pic-sure-instances">
 	{{#each this}}
@@ -8,7 +8,7 @@
 			<span class="col-md-2"></span>
 			<span class="col-md-4 center">{{name}}</span>
 			<span class="col-md-4 center" id="patient-count-{{id}}"></span>
-			<span class="col-md-2"></span>
+			<span class="col-md-1" id="spinner-{{id}}"></span>
 		</div>
 	{{/each}}
 	</div>

--- a/src/main/webapp/styles.css
+++ b/src/main/webapp/styles.css
@@ -45,8 +45,17 @@
     background-color: lightblue;
     padding: 10 10 10 10;
 }
+.filter-row {
+	width: 100%;
+}
+.search-box-spinner {
+    position: absolute !important;
+    right: 1.5em;
+    left: auto !important;
+}
 #pic-sure-instances {
 	width: 100%;
+}
 
 .spinner {
     position: absolute;
@@ -68,7 +77,7 @@
 .spinner-large {
     width: 60px;
     height: 60px;
-    border-width: 4px;
+    border-width: 10px;
     margin-top: 10px;
 }
 


### PR DESCRIPTION
- Moved all style information out of style attributes and into the css 
- pulled all spinner logic out and into common/spinner.js
- created common/spinner.hbs which holds the basic DOM element for spinners 
- updated query handling to not be as hard to follow
- added spinner per pic-sure api instance being queried
